### PR TITLE
Feat: Singlefeedback 수정기능 구현 

### DIFF
--- a/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
+++ b/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
@@ -1,0 +1,33 @@
+package fitback.fitbackBE.apicontroller;
+
+import fitback.fitbackBE.domain.Feedback;
+import fitback.fitbackBE.service.FeedbackService;
+import org.springframework.web.bind.annotation.*;
+
+public class feedbackApiController {
+    private final FeedbackService feedbackService;
+    /*피드백 작성
+    * @Date 220925 @Author 정희윤
+    * Dto: CreateFeedbackRequest(title 필수), CreateFeedbackResponse(id)
+    * title 저장, write로 DB저장, id로 변경된 feedbackResponse 조회해 리턴
+    */
+    @PostMapping("/v1/feedback")
+    public CreatedFeedbackResponse createFeedback(@RequestBody CreatedFeedbackRequest request){
+        Feedback feedback = new Feedback();
+        feedback.setTitle(request.getTitle());
+        Long id = feedbackService.write(feedback);
+        return new CreatedFeedbackResponse(id);
+    }
+
+
+
+    public class CreatedFeedbackRequest{
+        private String title;
+    }
+    private class CreatedFeedbackResponse {
+        private Long id;
+        public CreateFeedbackResponse(Long id){ this.id = id;}
+    }
+
+
+}

--- a/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
+++ b/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
@@ -6,10 +6,12 @@ import fitback.fitbackBE.domain.PublishType;
 import fitback.fitbackBE.domain.SessionType;
 import fitback.fitbackBE.mapper.FeedbackMapper;
 import fitback.fitbackBE.service.FeedbackService;
+import fitback.fitbackBE.utility.SingleResponseDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -31,16 +33,22 @@ public class feedbackApiController {
     @PostMapping
     public CreatedFeedbackResponse createFeedback(@RequestBody CreateFeedbackRequest request){
         Feedback feedback = feedbackService.write(mapper.mapCreateRqToFeedBack(request));
-
+        long id = feedback.getId();
         return new CreatedFeedbackResponse(id);
+        //ResponseEntity로 작성 or not 결정
     }
 
     @PatchMapping("/{feedback-id}")
     public ResponseEntity patchFeedback(@PathVariable("feedback-id")@Positive long id, PatchFeedbackRequest request){
         request.setFbId(id);
-        Feedback feedback = feedbackService.updateFeedback();
+        Feedback feedback = feedbackService.updateFeedback(mapper.mapPatchFbRqToFeedback(request));
 
+        return new ResponseEntity<>(
+                new SingleResponseDto<>(mapper.mapFbToPatchFbResponse(feedback)),
+                HttpStatus.OK);
     }
+
+
 
     @Data
     public static class CreateFeedbackRequest{
@@ -60,7 +68,7 @@ public class feedbackApiController {
     }
 
     @Data
-    private class PatchFeedbackRequest {
+    public static class PatchFeedbackRequest {
         private Long id;
         private String title;
         private String contents;
@@ -70,5 +78,15 @@ public class feedbackApiController {
         public void setFbId(long id) {
             this.id = id;
         }
+    }
+
+    @Builder
+    @Getter
+    public static class PatchedFbResponse {
+        private Long id;
+        private String title;
+        private String contents;
+        private SessionType sessionType;
+        private PublishType publishType;
     }
 }

--- a/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
+++ b/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
@@ -1,32 +1,55 @@
 package fitback.fitbackBE.apicontroller;
 
+import com.sun.istack.NotNull;
 import fitback.fitbackBE.domain.Feedback;
+import fitback.fitbackBE.domain.PublishType;
+import fitback.fitbackBE.domain.SessionType;
+import fitback.fitbackBE.mapper.FeedbackMapper;
 import fitback.fitbackBE.service.FeedbackService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+/*피드백 작성
+ * @Date 220925 @Author 정희윤
+ * Dto: CreateFeedbackRequest(title 필수), CreateFeedbackResponse(id)
+ * title 저장, write로 DB저장, id로 변경된 feedbackResponse 조회해 리턴
+ */
+@RestController
+@RequestMapping("/v1/feedback")
+@RequiredArgsConstructor
+@Validated
 public class feedbackApiController {
-    private final FeedbackService feedbackService;
-    /*피드백 작성
-    * @Date 220925 @Author 정희윤
-    * Dto: CreateFeedbackRequest(title 필수), CreateFeedbackResponse(id)
-    * title 저장, write로 DB저장, id로 변경된 feedbackResponse 조회해 리턴
-    */
-    @PostMapping("/v1/feedback")
+    private final  FeedbackService feedbackService;
+    private final FeedbackMapper mapper;
+
+    public feedbackApiController(FeedbackService feedbackService, FeedbackMapper mapper) {
+        this.feedbackService = feedbackService;
+        this.feedbackMapper = mapper;
+    }
+
+
+    @PostMapping
     public CreatedFeedbackResponse createFeedback(@RequestBody CreatedFeedbackRequest request){
-        Feedback feedback = new Feedback();
-        feedback.setTitle(request.getTitle());
-        Long id = feedbackService.write(feedback);
+        Feedback feedback = feedbackService.write(mapper.createRqToFeedBack(request));
+
         return new CreatedFeedbackResponse(id);
     }
 
 
-
-    public class CreatedFeedbackRequest{
+    @Data
+    public static class CreatedFeedbackRequest{//static으로 선언할지 고민중
+        @NotNull
         private String title;
+        private String contents;
+        private SessionType sessionType;
+        private PublishType publishType;
     }
-    private class CreatedFeedbackResponse {
+    @Data
+    public static class CreatedFeedbackResponse {//static으로 선언할지 고민중
         private Long id;
-        public CreateFeedbackResponse(Long id){ this.id = id;}
+        public CreatedFeedbackResponse(Long id){ this.id = id;}
     }
 
 

--- a/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
+++ b/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
@@ -6,8 +6,11 @@ import fitback.fitbackBE.domain.PublishType;
 import fitback.fitbackBE.domain.SessionType;
 import fitback.fitbackBE.mapper.FeedbackMapper;
 import fitback.fitbackBE.service.FeedbackService;
+import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,22 +27,23 @@ public class feedbackApiController {
     private final  FeedbackService feedbackService;
     private final FeedbackMapper mapper;
 
-    public feedbackApiController(FeedbackService feedbackService, FeedbackMapper mapper) {
-        this.feedbackService = feedbackService;
-        this.feedbackMapper = mapper;
-    }
-
 
     @PostMapping
-    public CreatedFeedbackResponse createFeedback(@RequestBody CreatedFeedbackRequest request){
-        Feedback feedback = feedbackService.write(mapper.createRqToFeedBack(request));
+    public CreatedFeedbackResponse createFeedback(@RequestBody CreateFeedbackRequest request){
+        Feedback feedback = feedbackService.write(mapper.mapCreateRqToFeedBack(request));
 
         return new CreatedFeedbackResponse(id);
     }
 
+    @PatchMapping("/{feedback-id}")
+    public ResponseEntity patchFeedback(@PathVariable("feedback-id")@Positive long id, PatchFeedbackRequest request){
+        request.setFbId(id);
+        Feedback feedback = feedbackService.upsateFeedback(mapper.mapPatchFbRqToFeedback(request));
+
+    }
 
     @Data
-    public static class CreatedFeedbackRequest{//static으로 선언할지 고민중
+    public static class CreateFeedbackRequest{
         @NotNull
         private String title;
         private String contents;
@@ -47,10 +51,16 @@ public class feedbackApiController {
         private PublishType publishType;
     }
     @Data
-    public static class CreatedFeedbackResponse {//static으로 선언할지 고민중
+    @Builder
+    @Getter
+    public static class CreatedFeedbackResponse {
         private Long id;
+
         public CreatedFeedbackResponse(Long id){ this.id = id;}
     }
 
 
+    private class PatchFeedbackRequest {
+
+    }
 }

--- a/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
+++ b/src/main/java/fitback/fitbackBE/apicontroller/feedbackApiController.java
@@ -38,7 +38,7 @@ public class feedbackApiController {
     @PatchMapping("/{feedback-id}")
     public ResponseEntity patchFeedback(@PathVariable("feedback-id")@Positive long id, PatchFeedbackRequest request){
         request.setFbId(id);
-        Feedback feedback = feedbackService.upsateFeedback(mapper.mapPatchFbRqToFeedback(request));
+        Feedback feedback = feedbackService.updateFeedback();
 
     }
 
@@ -59,8 +59,16 @@ public class feedbackApiController {
         public CreatedFeedbackResponse(Long id){ this.id = id;}
     }
 
-
+    @Data
     private class PatchFeedbackRequest {
+        private Long id;
+        private String title;
+        private String contents;
+        private SessionType sessionType;
+        private PublishType publishType;
 
+        public void setFbId(long id) {
+            this.id = id;
+        }
     }
 }

--- a/src/main/java/fitback/fitbackBE/domain/Feedback.java
+++ b/src/main/java/fitback/fitbackBE/domain/Feedback.java
@@ -1,0 +1,20 @@
+package fitback.fitbackBE.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+
+import java.time.LocalDate;
+@Getter
+@Setter
+public class Feedback {
+    @Id
+    private Long id;
+    private String title;
+    private String contents;
+    private SessionType sessionType;//REGULAR, EXTRA
+    private LocalDate createdTime;
+    private PublishType publishType;//OPEN,HIDE
+
+
+}

--- a/src/main/java/fitback/fitbackBE/domain/Feedback.java
+++ b/src/main/java/fitback/fitbackBE/domain/Feedback.java
@@ -1,19 +1,38 @@
 package fitback.fitbackBE.domain;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.data.annotation.Id;
+import lombok.*;
 
+import javax.persistence.*;
 import java.time.LocalDate;
-@Getter
-@Setter
+
+
+@Getter @Setter
+@Entity
+@Table(name="feedback")
+@RequiredArgsConstructor
 public class Feedback {
+
     @Id
+    @GeneratedValue
+    @Column(name="feedback_id")
     private Long id;
+
+//    @ManyToOne(fetch = LAZY)
+//    @JoinColumn(name="user_id")
+//    private User user;
+    @Column(length = 50, nullable = false)
     private String title;
+
+    @Column
     private String contents;
-    private SessionType sessionType;//REGULAR, EXTRA
-    private LocalDate createdTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private SessionType sessionType = SessionType.REGULAR;//수업 상태 [REGULAR, ABSENT, EXTRA]
+
+    private LocalDate createdTime;//작성시간
+
+    @Enumerated(EnumType.STRING)
     private PublishType publishType;//OPEN,HIDE
 
 

--- a/src/main/java/fitback/fitbackBE/domain/PublishType.java
+++ b/src/main/java/fitback/fitbackBE/domain/PublishType.java
@@ -1,0 +1,5 @@
+package fitback.fitbackBE.domain;
+
+public enum PublishType {
+    OPEN, HIDE
+}

--- a/src/main/java/fitback/fitbackBE/domain/SessionType.java
+++ b/src/main/java/fitback/fitbackBE/domain/SessionType.java
@@ -1,0 +1,5 @@
+package fitback.fitbackBE.domain;
+
+public enum SessionType {
+    REGULAR,EXTRA
+}

--- a/src/main/java/fitback/fitbackBE/domain/SessionType.java
+++ b/src/main/java/fitback/fitbackBE/domain/SessionType.java
@@ -1,5 +1,5 @@
 package fitback.fitbackBE.domain;
 
 public enum SessionType {
-    REGULAR,EXTRA
+    REGULAR,EXTRA,ABSENT
 }

--- a/src/main/java/fitback/fitbackBE/mapper/FeedbackMapper.java
+++ b/src/main/java/fitback/fitbackBE/mapper/FeedbackMapper.java
@@ -4,6 +4,12 @@ import fitback.fitbackBE.apicontroller.feedbackApiController;
 import fitback.fitbackBE.domain.Feedback;
 
 public interface FeedbackMapper {
-    public Feedback createRqToFeedBack(feedbackApiController.CreatedFeedbackRequest request) {
-    }
+    Feedback mapCreateRqToFeedBack(feedbackApiController.CreateFeedbackRequest createFbrequest);
+
+    feedbackApiController.CreatedFeedbackResponse mapFbToCreatedRp(Feedback feedback);
+
+    feedbackApiController.PatchedFbResponse mapFbToPatchFbResponse(Feedback feedback);
+
+    Feedback mapPatchFbRqToFeedback(feedbackApiController.PatchFeedbackRequest request);
+
 }

--- a/src/main/java/fitback/fitbackBE/mapper/FeedbackMapper.java
+++ b/src/main/java/fitback/fitbackBE/mapper/FeedbackMapper.java
@@ -1,0 +1,9 @@
+package fitback.fitbackBE.mapper;
+
+import fitback.fitbackBE.apicontroller.feedbackApiController;
+import fitback.fitbackBE.domain.Feedback;
+
+public interface FeedbackMapper {
+    public Feedback createRqToFeedBack(feedbackApiController.CreatedFeedbackRequest request) {
+    }
+}

--- a/src/main/java/fitback/fitbackBE/repository/FeedbackRepository.java
+++ b/src/main/java/fitback/fitbackBE/repository/FeedbackRepository.java
@@ -1,0 +1,15 @@
+package fitback.fitbackBE.repository;
+
+import fitback.fitbackBE.domain.Feedback;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+@Repository
+@RequiredArgsConstructor
+public interface FeedbackRepository extends JpaRepository {
+    private final EntityManager em;
+    public void save(Feedback feedback){em.persist(feedback);}
+
+}

--- a/src/main/java/fitback/fitbackBE/repository/FeedbackRepository.java
+++ b/src/main/java/fitback/fitbackBE/repository/FeedbackRepository.java
@@ -1,15 +1,13 @@
 package fitback.fitbackBE.repository;
 
 import fitback.fitbackBE.domain.Feedback;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 @Repository
-@RequiredArgsConstructor
-public interface FeedbackRepository extends JpaRepository {
+public interface FeedbackRepository extends JpaRepository<T, ID> {
     private final EntityManager em;
-    public void save(Feedback feedback){em.persist(feedback);}
+    public Feedback save(Feedback feedback){em.persist(feedback);}
 
 }

--- a/src/main/java/fitback/fitbackBE/service/FeedbackService.java
+++ b/src/main/java/fitback/fitbackBE/service/FeedbackService.java
@@ -1,10 +1,34 @@
 package fitback.fitbackBE.service;
 
 import fitback.fitbackBE.domain.Feedback;
+import fitback.fitbackBE.repository.FeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly=true)
 public class FeedbackService {
+    private final FeedbackRepository feedbackRepository;
+
     public Long write(Feedback feedback) {
         feedbackRepository.save(feedback);
         return feedback.getId();
+    }
+
+    public Feedback updateFeedback(Feedback feedback) {
+        Optional.ofNullable(feedback.getTitle())
+                .ifPresent(title-> feedback.setTitle(title));
+        Optional.ofNullable(feedback.getContents())
+                .ifPresent(contents-> feedback.setContents(contents));
+        Optional.ofNullable(feedback.getSessionType())
+                .ifPresent(sessionType-> feedback.setSessionType(sessionType));
+        Optional.ofNullable(feedback.getPublishType())
+                .ifPresent(publishType-> feedback.setPublishType(publishType));
+
+        return feedbackRepository.save(feedback);
     }
 }

--- a/src/main/java/fitback/fitbackBE/service/FeedbackService.java
+++ b/src/main/java/fitback/fitbackBE/service/FeedbackService.java
@@ -1,0 +1,10 @@
+package fitback.fitbackBE.service;
+
+import fitback.fitbackBE.domain.Feedback;
+
+public class FeedbackService {
+    public Long write(Feedback feedback) {
+        feedbackRepository.save(feedback);
+        return feedback.getId();
+    }
+}

--- a/src/main/java/fitback/fitbackBE/utility/SingleResponseDto.java
+++ b/src/main/java/fitback/fitbackBE/utility/SingleResponseDto.java
@@ -1,0 +1,10 @@
+package fitback.fitbackBE.utility;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SingleResponseDto<T> {
+    private T data;
+}


### PR DESCRIPTION
- [ ] 글 작성기능과 달리 수정기능은 ResponseEntity를 리턴하는 방식으로 구현했습니다.
- [ ] 요청을 엔티티로, 엔티티를 응답 데이터 형태로 매핑해주는 mapper 인터페이스를 작성했습니다.
- [ ] SingleResponseDto 클래스를 만들어 응답 시 http 상태와 응답 데이터를 리턴할 수 있도록  작성했습니다. 

작성한 코드에 설명이 필요하신 부분이 있으시다면 코드 클릭하셔서 리뷰 주석 달아주세요! 고생하셨습니다. 

